### PR TITLE
Minimal coordinate system trait

### DIFF
--- a/src/SpatioTemporalTraits.jl
+++ b/src/SpatioTemporalTraits.jl
@@ -36,6 +36,7 @@ export
     height
 
 include("spatial.jl")
+include("coordinate_systems.jl")
 include("temporal.jl")
 
 end # module

--- a/src/coordinate_systems.jl
+++ b/src/coordinate_systems.jl
@@ -1,17 +1,128 @@
 
 """
-    CoordinateSystem
+    CoordinateSystem(:Type{T})
 
-A trait for representing coordinate systems.
+* Required methods
+    * `Base.axes(::CoordinateSystem)`
+    * `ArrayInterface.axes_types(::Type{CoordinateSystem})`
+* Optional methods
+    * `Base.axes(::CoordinateSystem, dim::Int)`
+    * `Base.permutedims(::CoordinateSystem{1})`
+    * `Base.permutedims(::CoordinateSystem{2})`
+    * `Base.permutedims(::CoordinateSystem{N}, dims::Tuple{Vararg{Any,N}})`
 """
-abstract type CoordinateSystem end
+abstract type CoordinateSystem{N} end
 
-struct ImageCoordinates <: CoordinateSystem end
+Base.ndims(::Type{<:CoordinateSystem{N}}) where {N} = N::Int
 
+# TODO document that trailing axes are Cartesian unless otherwise specified
+@inline Base.axes(x::CoordinateSystem, dim::StaticInt{D}) where {D} = axes(x, D)
+@inline function Base.axes(x::CoordinateSystem{N}, dim::Int) where {N}
+    if dim > N
+        return CartesianAxis()
+    else
+        return getfield(axes(x), dim)
+    end
+end
+
+@inline function Base.permutedims(x::CoordinateSystem{1})
+    CartesianSystem(CartesianAxis(), getfield(axes(x), 1))
+end
+@inline Base.permutedims(x::CoordinateSystem{2}) = CartesianSystem(reverse(axes(x)))
+@inline function Base.permutedims(x::CoordinateSystem{N}, dims::Tuple{Vararg{Any,N}}) where {N}
+    CartesianSystem(map(d -> axes(x, d), dims))
+end
+
+"""
+    EulerAxis
+
+Represents an X, Y, or Z euler axis.
+"""
+struct EulerAxis{N} <: CoordinateSystem{1}
+    name::N
+
+    EulerAxis{StaticSymbol{:X}}(::StaticSymbol{:X}) = new{StaticSymbol{:X}}(StaticSymbol{:X}())
+    EulerAxis{StaticSymbol{:Y}}(::StaticSymbol{:Y}) = new{StaticSymbol{:Y}}(StaticSymbol{:Y}())
+    EulerAxis{StaticSymbol{:Z}}(::StaticSymbol{:Z}) = new{StaticSymbol{:Z}}(StaticSymbol{:Z}())
+    EulerAxis{StaticSymbol{:X}}() = EulerAxis{StaticSymbol{:X}}(StaticSymbol{:X}())
+    EulerAxis{StaticSymbol{:Y}}() = EulerAxis{StaticSymbol{:Y}}(StaticSymbol{:Y}())
+    EulerAxis{StaticSymbol{:Z}}() = EulerAxis{StaticSymbol{:Z}}(StaticSymbol{:Z}())
+    function EulerAxis{Symbol}(s::Symbol)
+        (s === :X || s === :Y || s === :Z) && return new{Symbol}(s)
+        error("EulerAxis must be :X, :Y, or :Z")
+    end
+    EulerAxis(x::Union{Symbol,StaticSymbol}) = EulerAxis{typeof(x)}(x)
+end
+const XAxis = EulerAxis{StaticSymbol{:X}}
+const YAxis = EulerAxis{StaticSymbol{:Y}}
+const ZAxis = EulerAxis{StaticSymbol{:Z}}
+
+Base.axes(x::EulerAxis) = (x,)
+
+"""
+    TemporalAxis
+
+Represents a temporal axis.
+"""
+struct TemporalAxis <: CoordinateSystem{1} end
+
+Base.axes(x::TemporalAxis) = (x,)
+
+"""
+    CartesianAxis
+
+Represents a generic axis of a cartesian coordinate system.
+"""
+struct CartesianAxis <: CoordinateSystem{1} end
+
+Base.axes(x::CartesianAxis) = (x,)
+
+"""
+    CartesianSystem
+    
+A subtype of `CoordinateSystem` composed of 
+"""
+struct CartesianSystem{N,A<:Tuple{Vararg{<:CoordinateSystem{1},N}}} <: CoordinateSystem{N}
+    axes::A
+end
+
+Base.axes(x::CartesianSystem) = getfield(x, :axes)
+
+## Arrays -> CoordinateSystem
 @inline function CoordinateSystem(::Type{T}) where {T}
     if parent_type(T) <: T
-        return ImageCoordinates()
+        return CartesianSystem(_maybe_eueler(map(CoordinateSystem, dimnames(T))))
     else
         return CoordinateSystem(parent_type(T))
     end
 end
+_maybe_euler(x) = x
+_maybe_euler(::Tuple{}) = CartesianAxis()
+_maybe_euler(::NTuple{1,StaticSymbol{:_}}) = CartesianSystem((XAxis(),))
+_maybe_euler(::NTuple{2,StaticSymbol{:_}}) = CartesianSystem((XAxis(),YAxis()))
+_maybe_euler(::NTuple{3,StaticSymbol{:_}}) = CartesianSystem((XAxis(),YAxis(), ZAxis()))
+function _maybe_euler(::NTuple{N,StaticSymbol{:_}}) where {N}
+    CartesianSystem((XAxis(),YAxis(), ZAxis(), ntuple(CartesianAxis(), Val(N - 3))))
+end
+
+CoordinateSystem(x::Union{Adjoint,Transpose}) = permutedims(CoordinateSystem(parent(x)))
+@inline function CoordinateSystem(x::PermutedDimsArray{T,N,I}) where {T,N,I}
+    permutdims(CoordinateSystem(parent(x)), static(I))
+end
+@inline function CoordinateSystem(x::SubArray)
+    CartesianSystem(Static.permute(axes(CoordinateSystem(parent(x))), to_parent_dims(x)))
+end
+if isdefined(Base, :ReshapedReinterpretArray)
+    @inline function CoordinateSystem(A::Base.ReshapedReinterpretArray{T,N,S}) where {T,N,S}
+        if sizeof(S) > sizeof(T)
+            return CartesianSystem(CoordinateSystem(T), axes(CoordinateSystem(parent(A)))...)
+        elseif sizeof(S) < sizeof(T)
+            return tail(axes(CoordinateSystem(parent(A))))
+        else
+            return CoordinateSystem(parent(A))
+        end
+    end
+end
+
+CoordinateSystem(::Type{Union{StaticSymbol{:Time},StaticSymbol{:time}}}) = TemporalAxis()
+CoordinateSystem(::Type{<:Dates.AbstractTime}) = TemporalAxis()

--- a/src/coordinate_systems.jl
+++ b/src/coordinate_systems.jl
@@ -1,0 +1,17 @@
+
+"""
+    CoordinateSystem
+
+A trait for representing coordinate systems.
+"""
+abstract type CoordinateSystem end
+
+struct ImageCoordinates <: CoordinateSystem end
+
+@inline function CoordinateSystem(::Type{T}) where {T}
+    if parent_type(T) <: T
+        return ImageCoordinates()
+    else
+        return CoordinateSystem(parent_type(T))
+    end
+end


### PR DESCRIPTION
Edit:
Following conversation and evolving use cases I've been encountering elsewhere, I've moved on from the original commit here of a simple trait to something a bit more flexible. Although I think this is headed in the right direction, there are a few rough spots I haven't fully thought through yet (so it remains a draft PR).

The overall goal here is probably best illustrated with the `EulerAxis` and `CartesianSystem` implementations. `EulerAxis` is a strict reference that can only be labeled as `:X`, `:Y`, or `:Z`. This label may be a `Symbol` if the information is dynamic (as it is in [ReferenceFrameRotations.jl](https://github.com/JuliaSpace/ReferenceFrameRotations.jl/blob/db736132fc96e3bc53b10b4a8c82a2a4ebc61bd3/src/types.jl#L78)) or static if it's known at compile time (as it is in [Rotations.jl](https://github.com/JuliaGeometry/Rotations.jl/blob/9fd3ea19d751efa9cdddba2693a1ef8d4162cd17/src/euler_types.jl#L16)). These may exist alongside other single dimensional systems within a `CartesianSystem`, the default system for array types.

`CoordinateSystem` is constructed and modified across layers of arrays, and the goal here is to enable metadata and specific array types to inform the `CoordinateSystem` instead of relying entirely on heuristics from named dimensions. For example, if we have `Base.ReshapedReinterpretArray` and the first dimension is just a color type, we could have `CoordinateSystem(::Type{<:Colorant}) = ColorAxis()` catch that information instead of hoping to catch it in a named dimension elsewhere.

Some things I still need to make decisions on are:
* How should coordinate system info derived from named dimensions merge with coordinate system info in nested layers?
* How should coordinate system traits be implemented in a way that facilitates collaboration with packages that actually manipulate coordinate systems (CoordinateTransformations.jl, Rotations.jl, ReferenceFrameRotations.jl,)?
